### PR TITLE
Allow SDK Extension pinning

### DIFF
--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -103,7 +103,7 @@ jobs:
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}
       sdk_extensions: >-
-        "https://github.com/Adminiuga/Raz1_custom_components_extension"
+        "https://github.com/Adminiuga/Raz1_custom_components_extension#0.0.2"
       sdkpatchpath: ''
       metadata_extra: "{}"
       flavor: ${{ inputs.flavor }}

--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -149,8 +149,17 @@ jobs:
           cd ${{ env.sdk_path }}/extension
           for EXT in ${{ inputs.sdk_extensions }}
           do
-            echo "Clonining ${EXT}"
-            git clone "$EXT"
+            if [ "$EXT" == "*#*" ]
+            then
+              URL="part1="${EXT%%#*}"
+              tag="${EXT#*#}""
+              echo "Clonining ${URL} with '${TAG}' tag"
+              git clone --depth 1 -b "${TAG}" "$URL"
+            else
+              EXT=$(echo $EXT | cut -d'#' -f1)
+              echo "Clonining ${EXT}"
+              git clone --depth 1 "$EXT"
+            fi
           done
 
       - name: Trust SDK Extenstions

--- a/MLight/MLight.slcp
+++ b/MLight/MLight.slcp
@@ -237,4 +237,5 @@ tag:
   - hardware:device:ram:64
 
 sdk_extension:
-  - {id: raz1_custom_components, version: 0.0.1}
+  - id: raz1_custom_components
+    version: 0.0.2


### PR DESCRIPTION
Allow checking out a specific tag/branch of the SDK extension, by specifying the GIT URL and providing branch/tag suffix, separated by `#` e.g. https://github.com/Adminiuga/Raz1_custom_components_extension#0.0.2"

Bump up Raz1 extension to 0.0.2 version