### PR TITLE
Update OTA versioning

### DIFF
--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -103,7 +103,7 @@ jobs:
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}
       sdk_extensions: >-
-        "https://github.com/Adminiuga/Raz1_custom_components_extension#0.0.2"
+        "https://github.com/Adminiuga/Raz1_custom_components_extension"
       sdkpatchpath: ''
       metadata_extra: "{}"
       flavor: ${{ inputs.flavor }}

--- a/.github/workflows/silabs-project-builder.yaml
+++ b/.github/workflows/silabs-project-builder.yaml
@@ -98,19 +98,19 @@ env:
   IS_NEW_PROJECT: ${{ inputs.export_project_name != '' && 'yes' || 'no' }}
   IS_BTL: ${{ startsWith(inputs.project_name, 'bootloader') && 'yes' || '' }}
   branch_to_ota: >-
-    ${{ github.ref_name == 'main'
-        && '0'
-        || (startsWith(github.ref_name, 'rc')
-            && '3'
+    ${{ ( github.ref_name == 'main' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')) )
+        && '9'
+        || ( (startsWith(github.ref_name, 'rc') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc')))
+            && '7'
             || ( github.ref_name == 'dev'
-                 && '8'
-                 || '6')
+                 && '5'
+                 || '4')
         )
     }}
   branch_to_build_type: >-
-    ${{ github.ref_name == 'main'
+    ${{ (github.ref_name == 'main' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')) )
         && 'rel'
-        || (startsWith(github.ref_name, 'rc')
+        || ( (startsWith(github.ref_name, 'rc')  || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc')) )
             && 'rc'
             || ( github.ref_name == 'dev'
                  && 'dev'


### PR DESCRIPTION
Refactor how the OTA versioning is calculated, affected by the TAG names

List of OTA version priorities in descending order:
- Releases (or main branch) have the highest priority
- Release Candidates
- Dev branch
- Any other branch

This means, a new Release Candidate should be released next day after the previous main release.