### PR TITLE
Indicate network status on startup.

### DIFF
--- a/MLight/app.c
+++ b/MLight/app.c
@@ -92,6 +92,7 @@ void emberAfMainInitCallback(void)
   #if SL_POWER_MANAGER_DEBUG == 1
   sl_power_manager_debug_print_em_requirements();
   #endif // SL_POWER_MANAGER_DEBUG == 1
+  dnjcInit();
 }
 
 /** @brief Start feedback.

--- a/MLight/app.c
+++ b/MLight/app.c
@@ -42,6 +42,7 @@
 
 #include "sl_dmp_ui_stub.h"
 
+#include "sl_simple_led_instances.h"
 #if defined(SL_CATALOG_RZ_LED_BLINK_PRESENT)
 #include <rz_led_blink.h>
 #include "mods/device-nwk-join-control.h"

--- a/MLight/app.c
+++ b/MLight/app.c
@@ -88,6 +88,9 @@ void emberAfMainInitCallback(void)
 {
   #if defined(SL_CATALOG_RZ_LED_BLINK_PRESENT)
   rz_led_blink_init();
+  #if SL_SIMPLE_LED_COUNT >= 1
+  rz_led_blink_blink_led_on( 500, 0 );
+  #endif
   #endif // SL_CATALOG_RZ_LED_BLINK_PRESENT
   #if SL_POWER_MANAGER_DEBUG == 1
   sl_power_manager_debug_print_em_requirements();

--- a/MLight/app.h
+++ b/MLight/app.h
@@ -8,22 +8,6 @@
 #include "sl_sleeptimer.h"
 #define TIMESTAMP_MS (sl_sleeptimer_tick_to_ms(sl_sleeptimer_get_tick_count()))
 
-#if defined(SL_CATALOG_LED0_PRESENT)
-#include "sl_led.h"
-#include "sl_simple_led_instances.h"
-#define led_turn_on(led) sl_led_turn_on(led)
-#define led_turn_off(led) sl_led_turn_off(led)
-#define led_toggle(led) sl_led_toggle(led)
-#define LED0     (&sl_led_led0)
-#if defined(SL_CATALOG_LED1_PRESENT)
-#define LED1     (&sl_led_led1)
-#endif // SL_CATALOG_LED1_PRESENT
-#else // !SL_CATALOG_LED0_PRESENT
-#define led_turn_on(led)
-#define led_turn_off(led)
-#define led_toggle(led)
-#endif // SL_CATALOG_LED0_PRESENT
-
 #define BUTTON0         0
 #define BUTTON1         1
 

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -95,7 +95,7 @@ SL_WEAK void dnjcDeviceLeftNwkCb(void)
 void emberAfStackStatusCallback(EmberStatus status)
 {
   EmberNetworkStatus nwkState = emberAfNetworkState();
-  emberAfCorePrintln("Stack status=0x%X, nwkState=%d", status, nwkState);
+  sl_zigbee_app_debug_println("%d (dnjc) Stack status=0x%X, nwkState=%d", TIMESTAMP_MS, status, nwkState);
 
   switch (nwkState) {
     case EMBER_NO_NETWORK:
@@ -203,7 +203,7 @@ EmberNetworkStatus dnjcInit(void)
 EmberNetworkStatus dnjcIndicateNetworkState(void)
 {
   EmberNetworkStatus nwkState = emberAfNetworkState();
-  sl_zigbee_app_debug_println("Indicating Current Network State: %d", nwkState);
+  sl_zigbee_app_debug_println("%d Indicating Current Network State: %d", TIMESTAMP_MS, nwkState);
 
   switch (nwkState) {
     case EMBER_JOINED_NETWORK:
@@ -220,7 +220,7 @@ EmberNetworkStatus dnjcIndicateNetworkState(void)
         LED_BLINK_LONG_MS,  // interblink pause
         LED_BLINK_LONG_MS,  // LED On Blink
       };
-      rz_led_blink_pattern(1, sizeof(pattern), pattern, COMMISSIONING_STATUS_LED);
+      rz_led_blink_pattern(1, sizeof(pattern)/sizeof(pattern[0]), pattern, COMMISSIONING_STATUS_LED);
       break;
 
     case EMBER_NO_NETWORK:
@@ -270,6 +270,7 @@ void _event_handler(sl_zigbee_event_t *event)
 
   if ( EMBER_JOINED_NETWORK == nwkState
        || EMBER_JOINED_NETWORK_NO_PARENT == nwkState ) {
+    sl_zigbee_app_debug_println("%d dnjc startup nwk status", TIMESTAMP_MS);
     dnjcIndicateNetworkState();
   } else {
     // should not be leaving, but if we are, then reschedule

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -15,10 +15,10 @@
 #define rz_led_blink_pattern(count, length, pattern, ledIndex)
 #endif // SL_CATALOG_RZ_LED_BLINK_PRESENT
 
-#define LED_BLINK_SHORT_MS         100
+#define LED_BLINK_SHORT_MS         150
 #define LED_BLINK_LONG_MS          750
 #define LED_BLINK_IDENTIFY_MS      500
-#define LED_BLINK_NETWORK_UP_COUNT 3
+#define LED_BLINK_NETWORK_UP_COUNT 5
 
 
 typedef struct {

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -15,7 +15,7 @@
 #define rz_led_blink_pattern(count, length, pattern, ledIndex)
 #endif // SL_CATALOG_RZ_LED_BLINK_PRESENT
 
-#define LED_BLINK_SHORT_MS         150
+#define LED_BLINK_SHORT_MS         100
 #define LED_BLINK_LONG_MS          750
 #define LED_BLINK_IDENTIFY_MS      500
 #define LED_BLINK_NETWORK_UP_COUNT 5

--- a/MLight/mods/device-nwk-join-control.h
+++ b/MLight/mods/device-nwk-join-control.h
@@ -1,6 +1,18 @@
 #ifndef _DEVICE_NWK_JOIN_CONTROL_H_
 #define _DEVICE_NWK_JOIN_CONTROL_H_
 
+#ifndef DNJC_STARTUP_STATUS_DELAY_MS
+#define DNJC_STARTUP_STATUS_DELAY_MS 3000
+#endif
+
+/**
+ * @brief Initialize the Device Network Join Control plugin
+ *        Sets the delay to indicate the network status on startup.
+ *        If the network is not up after the DNJC_STARTUP_STATUS_DELAY_MS,
+ *        then initiate network steering.
+ */
+EmberNetworkStatus dnjcInit(void);
+
 /**
  * @brief Indicate network status. Short 3 blinks is on network.
  *        Short and Long blink -- no parent. Long blink -- no network.


### PR DESCRIPTION
Upon startup, blink the led once, then after the `DNJC_STARTUP_STATUS_DELAY_MS` indicate the network status. If not online, then start the network steering.
