### PR TITLE
Update IMAGE_IDs

### DIFF
--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -101,7 +101,7 @@ jobs:
         ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
         ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
         SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:%d%d', inputs.image_id, matrix.image_id_subtype) || '' }},
+        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:{0}{1}', inputs.image_id, matrix.image_id_subtype) || '' }},
       remove_components: ${{ matrix.without }}
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}
@@ -155,7 +155,7 @@ jobs:
         ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
         ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
         SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:%d%d', inputs.image_id, matrix.image_id_subtype) || '' }},
+        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:{0}{1}', inputs.image_id, matrix.image_id_subtype) || '' }},
       remove_components: ${{ matrix.without }}
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}

--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -89,38 +89,27 @@ jobs:
           - name_suffix: debug
             image_id_subtype: 7
 
-    runs-on: ubuntu-latest
-    steps:
-      - id: image_id
-        if: ${{ inputs.image_id != 0 }}
-        name: Derive IMAGE_ID from inputs and image_id_subtype
-        shell: bash
-        run: |
-          IMAGE_ID=$(expr ${{ inputs.image_id }} + ${{ matrix.image_id_subtype }})
-          echo "IMAGE_ID=${IMAGE_ID}" >> "GITHUB_OUTPUT"
-          echo "Using ${IMAGE_ID} as IMAGE_ID"
- 
-      - uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
-        with:
-          image_name: ${{ inputs.image_name }}
-          src_project: MLight
-          model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
-          project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
-          device: ${{ inputs.device }}
-          components: ${{ inputs.components }}
-          configuration: >-
-            ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
-            ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
-            SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-            ${{ inputs.image_id != 0 && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:%d', steps.image_id.outputs.IMAGE_ID) || '' }},
-          remove_components: ${{ matrix.without }}
-          extra_c_defs: ""
-          sdk_version: ${{ inputs.sdk_version }}
-          metadata_extra: "{}"
-          ota_string: ${{ inputs.app_ota_string }}
-          sdk_extensions: >-
-            "https://github.com/Adminiuga/Raz1_custom_components_extension"
-          with_bootloader: ${{ needs.bootloader-build.outputs.project_name }}
+    uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
+    with:
+      image_name: ${{ inputs.image_name }}
+      src_project: MLight
+      model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
+      project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
+      device: ${{ inputs.device }}
+      components: ${{ inputs.components }}
+      configuration: >-
+        ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
+        ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
+        SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
+        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:%d%d', inputs.image_id, matrix.image_id_subtype) || '' }},
+      remove_components: ${{ matrix.without }}
+      extra_c_defs: ""
+      sdk_version: ${{ inputs.sdk_version }}
+      metadata_extra: "{}"
+      ota_string: ${{ inputs.app_ota_string }}
+      sdk_extensions: >-
+        "https://github.com/Adminiuga/Raz1_custom_components_extension"
+      with_bootloader: ${{ needs.bootloader-build.outputs.project_name }}
 
   app-firmware-build:
     if: ${{ !inputs.build_btl }}
@@ -154,37 +143,26 @@ jobs:
           - name_suffix: debug
             image_id_subtype: 7
 
-    runs-on: ubuntu-latest
-    steps:
-      - id: image_id
-        if: ${{ inputs.image_id != 0 }}
-        name: Derive IMAGE_ID from inputs and image_id_subtype
-        shell: bash
-        run: |
-          IMAGE_ID=$(expr ${{ inputs.image_id }} + ${{ matrix.image_id_subtype }})
-          echo "IMAGE_ID=${IMAGE_ID}" >> "GITHUB_OUTPUT"
-          echo "Using ${IMAGE_ID} as IMAGE_ID"
- 
-
-      - uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
-        with:
-          image_name: ${{ inputs.image_name }}
-          src_project: MLight
-          model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
-          project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
-          device: ${{ inputs.device }}
-          components: ${{ inputs.components }}
-          configuration: >-
-            ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
-            ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
-            SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-          remove_components: ${{ matrix.without }}
-          extra_c_defs: ""
-          sdk_version: ${{ inputs.sdk_version }}
-          metadata_extra: "{}"
-          ota_string: ${{ inputs.app_ota_string }}
-          sdk_extensions: >-
-            "https://github.com/Adminiuga/Raz1_custom_components_extension"
+    uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
+    with:
+      image_name: ${{ inputs.image_name }}
+      src_project: MLight
+      model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
+      project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
+      device: ${{ inputs.device }}
+      components: ${{ inputs.components }}
+      configuration: >-
+        ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
+        ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
+        SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
+        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:%d%d', inputs.image_id, matrix.image_id_subtype) || '' }},
+      remove_components: ${{ matrix.without }}
+      extra_c_defs: ""
+      sdk_version: ${{ inputs.sdk_version }}
+      metadata_extra: "{}"
+      ota_string: ${{ inputs.app_ota_string }}
+      sdk_extensions: >-
+        "https://github.com/Adminiuga/Raz1_custom_components_extension"
 
   bootloader-build:
     if: inputs.build_btl

--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -101,7 +101,7 @@ jobs:
         ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
         ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
         SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:{0}{1}', inputs.image_id, matrix.image_id_subtype) || '' }},
+        ${{ inputs.image_id && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:{0}{1}', inputs.image_id, matrix.image_id_subtype) || '' }},
       remove_components: ${{ matrix.without }}
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}
@@ -155,7 +155,7 @@ jobs:
         ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
         ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
         SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-        ${{ inputs.image_id != 0 && matrix.image_id_subtype && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:{0}{1}', inputs.image_id, matrix.image_id_subtype) || '' }},
+        ${{ inputs.image_id && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:{0}{1}', inputs.image_id, matrix.image_id_subtype) || '' }},
       remove_components: ${{ matrix.without }}
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}

--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -41,6 +41,11 @@ on:
         type: string
         default: Raz-1 Just a Light
 
+      image_id:
+        required: false
+        type: number
+        default: 0
+
       btl_version:
         required: true
         type: string
@@ -59,9 +64,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name_suffix: debug
-
           - name_suffix: sed
+            image_id_subtype: 0
             without: >-
               debug_swo
             configuration: >-
@@ -72,6 +76,7 @@ jobs:
               SL_ZIGBEE_DEBUG_ZCL_GROUP_RUNTIME_DEFAULT:0
 
           - name_suffix: end-device
+            image_id_subtype: 1
             without: >-
               debug_swo
             configuration: >-
@@ -81,26 +86,41 @@ jobs:
               SL_ZIGBEE_DEBUG_APP_GROUP_RUNTIME_DEFAULT:0,
               SL_ZIGBEE_DEBUG_ZCL_GROUP_RUNTIME_DEFAULT:0
 
-    uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
-    with:
-      image_name: ${{ inputs.image_name }}
-      src_project: MLight
-      model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
-      project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
-      device: ${{ inputs.device }}
-      components: ${{ inputs.components }}
-      configuration: >-
-        ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
-        ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
-        SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-      remove_components: ${{ matrix.without }}
-      extra_c_defs: ""
-      sdk_version: ${{ inputs.sdk_version }}
-      metadata_extra: "{}"
-      ota_string: ${{ inputs.app_ota_string }}
-      sdk_extensions: >-
-        "https://github.com/Adminiuga/Raz1_custom_components_extension"
-      with_bootloader: ${{ needs.bootloader-build.outputs.project_name }}
+          - name_suffix: debug
+            image_id_subtype: 7
+
+    runs-on: ubuntu-latest
+    steps:
+      - id: image_id
+        if: ${{ inputs.image_id != 0 }}
+        name: Derive IMAGE_ID from inputs and image_id_subtype
+        shell: bash
+        run: |
+          IMAGE_ID=$(expr ${{ inputs.image_id }} + ${{ matrix.image_id_subtype }})
+          echo "IMAGE_ID=${IMAGE_ID}" >> "GITHUB_OUTPUT"
+          echo "Using ${IMAGE_ID} as IMAGE_ID"
+ 
+      - uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
+        with:
+          image_name: ${{ inputs.image_name }}
+          src_project: MLight
+          model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
+          project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
+          device: ${{ inputs.device }}
+          components: ${{ inputs.components }}
+          configuration: >-
+            ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
+            ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
+            SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
+            ${{ inputs.image_id != 0 && format(',EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:%d', steps.image_id.outputs.IMAGE_ID) || '' }},
+          remove_components: ${{ matrix.without }}
+          extra_c_defs: ""
+          sdk_version: ${{ inputs.sdk_version }}
+          metadata_extra: "{}"
+          ota_string: ${{ inputs.app_ota_string }}
+          sdk_extensions: >-
+            "https://github.com/Adminiuga/Raz1_custom_components_extension"
+          with_bootloader: ${{ needs.bootloader-build.outputs.project_name }}
 
   app-firmware-build:
     if: ${{ !inputs.build_btl }}
@@ -109,9 +129,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name_suffix: debug
-
           - name_suffix: sed
+            image_id_subtype: 0
             without: >-
               debug_swo
             configuration: >-
@@ -122,6 +141,7 @@ jobs:
               SL_ZIGBEE_DEBUG_ZCL_GROUP_RUNTIME_DEFAULT:0
 
           - name_suffix: end-device
+            image_id_subtype: 1
             without: >-
               debug_swo
             configuration: >-
@@ -131,25 +151,40 @@ jobs:
               SL_ZIGBEE_DEBUG_APP_GROUP_RUNTIME_DEFAULT:0,
               SL_ZIGBEE_DEBUG_ZCL_GROUP_RUNTIME_DEFAULT:0
 
-    uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
-    with:
-      image_name: ${{ inputs.image_name }}
-      src_project: MLight
-      model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
-      project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
-      device: ${{ inputs.device }}
-      components: ${{ inputs.components }}
-      configuration: >-
-        ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
-        ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
-        SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
-      remove_components: ${{ matrix.without }}
-      extra_c_defs: ""
-      sdk_version: ${{ inputs.sdk_version }}
-      metadata_extra: "{}"
-      ota_string: ${{ inputs.app_ota_string }}
-      sdk_extensions: >-
-        "https://github.com/Adminiuga/Raz1_custom_components_extension"
+          - name_suffix: debug
+            image_id_subtype: 7
+
+    runs-on: ubuntu-latest
+    steps:
+      - id: image_id
+        if: ${{ inputs.image_id != 0 }}
+        name: Derive IMAGE_ID from inputs and image_id_subtype
+        shell: bash
+        run: |
+          IMAGE_ID=$(expr ${{ inputs.image_id }} + ${{ matrix.image_id_subtype }})
+          echo "IMAGE_ID=${IMAGE_ID}" >> "GITHUB_OUTPUT"
+          echo "Using ${IMAGE_ID} as IMAGE_ID"
+ 
+
+      - uses: zha-ng/workflows-silabs/.github/workflows/slc-project-builder.yaml@v1
+        with:
+          image_name: ${{ inputs.image_name }}
+          src_project: MLight
+          model: MLight${{ inputs.flavor != '' && format('-{0}', inputs.flavor) || '' }}
+          project_name: MLight-${{ inputs.flavor }}-${{ matrix.name_suffix }}
+          device: ${{ inputs.device }}
+          components: ${{ inputs.components }}
+          configuration: >-
+            ${{ inputs.configuration != '' && format('{0},', inputs.configuration) || '' }}
+            ${{ matrix.configuration != '' && format('{0},', matrix.configuration) || '' }}
+            SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE:32
+          remove_components: ${{ matrix.without }}
+          extra_c_defs: ""
+          sdk_version: ${{ inputs.sdk_version }}
+          metadata_extra: "{}"
+          ota_string: ${{ inputs.app_ota_string }}
+          sdk_extensions: >-
+            "https://github.com/Adminiuga/Raz1_custom_components_extension"
 
   bootloader-build:
     if: inputs.build_btl

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,15 +56,15 @@ jobs:
               custom_tb2;raz1_custom_components,
               mx25_flash_shutdown_usart
             flavor: TBS2
-            image_id: 18296
+            image_id: 2287
           - device: MGM210LA22JIF
             components: >-
               brd_mgm210_expansion;raz1_custom_components,
             flavor: MGM210
-            image_id: 18288
+            image_id: 2286
           - device: brd4181b
             flavor: brd4181b
-            image_id: 18304
+            image_id: 2288
     uses: ./.github/workflows/app-btl-build.yaml
     with:
       sdk_version: ${{ needs.build-container.outputs.sdk_version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,15 +56,15 @@ jobs:
               custom_tb2;raz1_custom_components,
               mx25_flash_shutdown_usart
             flavor: TBS2
-            image_id: 2287
+            image_id: 18296
           - device: MGM210LA22JIF
             components: >-
               brd_mgm210_expansion;raz1_custom_components,
             flavor: MGM210
-            image_id: 2286
+            image_id: 18288
           - device: brd4181b
             flavor: brd4181b
-            image_id: 2288
+            image_id: 18304
     uses: ./.github/workflows/app-btl-build.yaml
     with:
       sdk_version: ${{ needs.build-container.outputs.sdk_version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,16 +56,15 @@ jobs:
               custom_tb2;raz1_custom_components,
               mx25_flash_shutdown_usart
             flavor: TBS2
-            configuration: >-
-              EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:2287
+            image_id: 2287
           - device: MGM210LA22JIF
             components: >-
               brd_mgm210_expansion;raz1_custom_components,
             flavor: MGM210
+            image_id: 2286
           - device: brd4181b
             flavor: brd4181b
-            configuration: >-
-              EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID:2288
+            image_id: 2288
     uses: ./.github/workflows/app-btl-build.yaml
     with:
       sdk_version: ${{ needs.build-container.outputs.sdk_version }}
@@ -76,4 +75,5 @@ jobs:
       btl_version: ${{ vars.btl_version != '' && vars.btl_version || '2' }}
       flavor: ${{ matrix.flavor }}
       configuration: ${{ matrix.configuration }}
+      image_id: ${{ matrix.image_id }}
 

--- a/MLight/MLight.slcp
+++ b/MLight/MLight.slcp
@@ -174,17 +174,17 @@ configuration:
   - name: configMAX_TASK_NAME_LEN
     value: 30
   - name: EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID
-    value: 2286
+    value: 18288
     condition:
       - mgm210la22jif
       - zigbee_ota_client
   - name: EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID
-    value: 2287
+    value: 18296
     condition:
       - efr32mg12p332f1024gl125
       - zigbee_ota_client
   - name: EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID
-    value: 2288
+    value: 18304
     condition:
       - brd4181b
       - zigbee_ota_client

--- a/MLight/MLight.slcp
+++ b/MLight/MLight.slcp
@@ -174,22 +174,22 @@ configuration:
   - name: configMAX_TASK_NAME_LEN
     value: 30
   - name: EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID
-    value: 18288
+    value: 22860
     condition:
       - mgm210la22jif
       - zigbee_ota_client
   - name: EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID
-    value: 18296
+    value: 22870
     condition:
       - efr32mg12p332f1024gl125
       - zigbee_ota_client
   - name: EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_IMAGE_TYPE_ID
-    value: 18304
+    value: 22880
     condition:
       - brd4181b
       - zigbee_ota_client
   - name: EMBER_AF_PLUGIN_OTA_CLIENT_POLICY_FIRMWARE_VERSION
-    value: 241226000
+    value: 250122000
     condition:
       - zigbee_ota_client
   - name: EMBER_AF_PLUGIN_OTA_STORAGE_SIMPLE_EEPROM_GECKO_BOOTLOADER_STORAGE_SUPPORT


### PR DESCRIPTION
Add to the original `image_id` a sub id to represent different types of build, e.g. 0 for sleepy end device, 1 for non sleepy end device, etc. 
For example, IMAGE_ID for MGM210LA22 becomes `22860` and the default build as a SED devices becomes 22860, end_device is build with `image_id == 22861` and the debug version is built with `image_id == 22867`