### PR TITLE
Changes to network joining and leaving

### DIFF
--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -110,12 +110,10 @@ void emberAfStackStatusCallback(EmberStatus status)
 
   switch (nwkState) {
     case EMBER_NO_NETWORK:
-      if ( dnjcState.leavingNwk ) {
-        // We voluntarily left the network, try to rejoin
-        sl_zigbee_event_set_inactive( &dnjcState.dnjcEvent );
-        dnjcState.smPostTransition = _event_state_indicate_startup_nwk;
-        sl_zigbee_event_set_delay_ms( &dnjcState.dnjcEvent, DNJC_STARTUP_STATUS_DELAY_MS );
-      }
+      // Keep trying finding the network
+      sl_zigbee_event_set_inactive( &dnjcState.dnjcEvent );
+      dnjcState.smPostTransition = _event_state_indicate_startup_nwk;
+      sl_zigbee_event_set_delay_ms( &dnjcState.dnjcEvent, DNJC_STARTUP_STATUS_DELAY_MS );
       dnjcState.leavingNwk = false; // leave has completed.
       stopIdentifying();
       break;

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -111,6 +111,7 @@ void emberAfStackStatusCallback(EmberStatus status)
   switch (nwkState) {
     case EMBER_NO_NETWORK:
       dnjcState.leavingNwk = false; // leave has completed.
+      stopIdentifying();
       break;
     default:
       break;
@@ -345,6 +346,7 @@ void _indicate_leaving_nwk(void)
 {
   rz_led_blink_blink_led_on(LED_BLINK_LONG_MS, COMMISSIONING_STATUS_LED);
   dnjcState.smPostTransition = _post_indicate_leaving_nwk;
+  stopIdentifying();
   sl_zigbee_event_set_inactive(&dnjcState.dnjcEvent);
   sl_zigbee_event_set_delay_ms(&dnjcState.dnjcEvent, LED_BLINK_LONG_MS);
 }

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -138,6 +138,7 @@ void app_button_press_cb(uint8_t button, uint8_t duration)
     EmberNetworkStatus state = dnjcIndicateNetworkState();
     if (state == EMBER_NO_NETWORK) {
       // no network, short or long press -> start network steering
+      dnjcState.isCurrentlySteering = true;
       emberAfPluginNetworkSteeringStart();
     } else {
       // there's network, short or long press
@@ -185,6 +186,7 @@ void emberAfPluginNetworkSteeringCompleteCallback(EmberStatus status,
     "Network Steering Complete: status=0x%X, totalBeacons=%d, joinAttempts=%d, finalState=%d",
     status, totalBeacons, joinAttempts, finalState);
   dnjcIndicateNetworkState();
+  dnjcState.isCurrentlySteering = false;
   if (status == EMBER_SUCCESS) {
     startIdentifying();
   } else {
@@ -364,6 +366,7 @@ void _post_indicate_leaving_nwk(void)
 void _indicate_start_steering_nwk(void)
 {
   rz_led_blink_blink_led_on(LED_BLINK_LONG_MS << 1, COMMISSIONING_STATUS_LED);
+  dnjcState.isCurrentlySteering = true;
   emberAfPluginNetworkSteeringStart();
 }
 

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -110,6 +110,12 @@ void emberAfStackStatusCallback(EmberStatus status)
 
   switch (nwkState) {
     case EMBER_NO_NETWORK:
+      if ( dnjcState.leavingNwk ) {
+        // We voluntarily left the network, try to rejoin
+        sl_zigbee_event_set_inactive( &dnjcState.dnjcEvent );
+        dnjcState.smPostTransition = _event_state_indicate_startup_nwk;
+        sl_zigbee_event_set_delay_ms( &dnjcState.dnjcEvent, DNJC_STARTUP_STATUS_DELAY_MS );
+      }
       dnjcState.leavingNwk = false; // leave has completed.
       stopIdentifying();
       break;


### PR DESCRIPTION
Visually indicate when leaving the network or when starting network steering.
If the network goes down, then continuously try rejoining with exponential back off.
For sleepy end devices, back off  up to 2^15 seconds. For all other devices, backup up to 4096 seconds.