### PR TITLE
Use enhanced routing component for router image builds

### DIFF
--- a/MLight/MLight.slcp
+++ b/MLight/MLight.slcp
@@ -21,6 +21,8 @@ component:
   - id: zigbee_end_device_support
     condition: [ zigbee_pro_leaf_stack ]
   - id: zigbee_source_route
+  - id: zigbee_enhanced_routing
+    condition: [ zigbee_pro_router_stack, zigbee_r23_support ]
   - id: bluetooth_stack
   - id: gatt_configuration
   - id: bluetooth_feature_system


### PR DESCRIPTION
For Router image builds, use the enhanced routing component.