### PR TITLE
Apply SDK patches

### DIFF
--- a/.github/workflows/app-btl-build.yaml
+++ b/.github/workflows/app-btl-build.yaml
@@ -130,6 +130,7 @@ jobs:
       remove_components: ${{ matrix.without }}
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}
+      sdkpatchpath: "patches/app/v${{ inputs.sdk_version }}"
       metadata_extra: "{}"
       ota_string: ${{ inputs.app_ota_string }}
       sdk_extensions: >-
@@ -209,6 +210,7 @@ jobs:
       remove_components: ${{ matrix.without }}
       extra_c_defs: ""
       sdk_version: ${{ inputs.sdk_version }}
+      sdkpatchpath: "patches/app/v${{ inputs.sdk_version }}"
       metadata_extra: "{}"
       ota_string: ${{ inputs.app_ota_string }}
       sdk_extensions: >-


### PR DESCRIPTION
Since all projects are now being exported during the generation, the SDK patch needs to be re-applied.