### PR TITLE
Adjust number of rejoin attempts

### DIFF
--- a/MLight/MLight.slcp
+++ b/MLight/MLight.slcp
@@ -134,7 +134,11 @@ configuration:
     condition:
       - zigbee_end_device_support
   - name: EMBER_AF_PLUGIN_END_DEVICE_SUPPORT_WAKE_TIMEOUT_SECONDS
-    value: 1.5f
+    value: 3
+    condition:
+      - zigbee_end_device_support
+  - name: EMBER_AF_REJOIN_ATTEMPTS_MAX
+    value: 128
     condition:
       - zigbee_end_device_support
   - name: SL_IOSTREAM_USART_VCOM_RESTRICT_ENERGY_MODE_TO_ALLOW_RECEPTION

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -115,9 +115,9 @@ void emberAfStackStatusCallback(EmberStatus status)
   EmberNetworkStatus nwkState = emberAfNetworkState();
   sl_zigbee_app_debug_println("%d (dnjc) Stack status=0x%X, nwkState=%d", TIMESTAMP_MS, status, nwkState);
 
+  bool is_moving;
   switch (nwkState) {
     case EMBER_NO_NETWORK:
-    case EMBER_JOINED_NETWORK_NO_PARENT:
       // Keep trying finding the network
       sl_zigbee_event_set_inactive( &dnjcState.dnjcEvent );
       dnjcState.smPostTransition = _event_state_indicate_startup_nwk;
@@ -125,6 +125,12 @@ void emberAfStackStatusCallback(EmberStatus status)
       dnjcState.leavingNwk = false; // leave has completed.
       stopIdentifying();
       break;
+
+    case EMBER_JOINED_NETWORK_NO_PARENT:
+      is_moving = emberAfMoveInProgressCallback();
+      sl_zigbee_app_debug_println("EMBER_JOINED_NETWORK_NO_PARENT, is_moving=%d", is_moving);
+      break;
+
     default:
       break;
   }

--- a/MLight/mods/device-nwk-join-control.c
+++ b/MLight/mods/device-nwk-join-control.c
@@ -115,7 +115,6 @@ void emberAfStackStatusCallback(EmberStatus status)
   EmberNetworkStatus nwkState = emberAfNetworkState();
   sl_zigbee_app_debug_println("%d (dnjc) Stack status=0x%X, nwkState=%d", TIMESTAMP_MS, status, nwkState);
 
-  bool is_moving;
   switch (nwkState) {
     case EMBER_NO_NETWORK:
       // Keep trying finding the network
@@ -127,8 +126,7 @@ void emberAfStackStatusCallback(EmberStatus status)
       break;
 
     case EMBER_JOINED_NETWORK_NO_PARENT:
-      is_moving = emberAfMoveInProgressCallback();
-      sl_zigbee_app_debug_println("EMBER_JOINED_NETWORK_NO_PARENT, is_moving=%d", is_moving);
+      sl_zigbee_app_debug_println("EMBER_JOINED_NETWORK_NO_PARENT");
       break;
 
     default:

--- a/MLight/mods/device-nwk-join-control.h
+++ b/MLight/mods/device-nwk-join-control.h
@@ -2,7 +2,7 @@
 #define _DEVICE_NWK_JOIN_CONTROL_H_
 
 #ifndef DNJC_STARTUP_STATUS_DELAY_MS
-#define DNJC_STARTUP_STATUS_DELAY_MS 3000
+#define DNJC_STARTUP_STATUS_DELAY_MS 5000
 #endif
 
 #include <af-types.h>


### PR DESCRIPTION
Set the rejoin attempts number to 128.
Don't start network steering if the parent is lost, let the end-device-support handle the rejoin.